### PR TITLE
Add a "permessive" match strategy on include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .project
 .classpath
 /.svn
+nb-configuration.xml

--- a/src/main/java/ch/mfrey/jackson/antpathfilter/AntPathPropertyFilter.java
+++ b/src/main/java/ch/mfrey/jackson/antpathfilter/AntPathPropertyFilter.java
@@ -152,7 +152,7 @@ public class AntPathPropertyFilter extends SimpleBeanPropertyFilter {
         boolean include = false;
         // Check Includes first
         for (String pattern : _propertiesToInclude) {
-            if (matchPath(pathToTest, pattern)) {
+            if (permissiveMatchPath(pathToTest, pattern)) {
                 include = true;
                 break;
             }
@@ -173,9 +173,19 @@ public class AntPathPropertyFilter extends SimpleBeanPropertyFilter {
     }
 
     /**
+     * Only uses AntPathMatcher matchStart for adding properties
+     *
+     * @param pathToTest
+     * @param pattern
+     * @return
+     */
+    private boolean permissiveMatchPath(String pathToTest, String pattern) {
+        return MATCHER.matchStart(pattern, pathToTest);
+    }
+    /**
      * Only uses AntPathMatcher if the pattern contains wildcards, else use
      * simple equals
-     * 
+     *
      * @param pathToTest
      * @param pattern
      * @return

--- a/src/test/java/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest.java
+++ b/src/test/java/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest.java
@@ -7,101 +7,134 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ch.mfrey.jackson.antpathfilter.Jackson2Helper;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class AntPathFilterTest {
+
     private final Jackson2Helper jackson2Helper = new Jackson2Helper();
+    private final ObjectMapper defaultJackson = new ObjectMapper();
 
-    private void assertAntFilter(final Object testObj, final String[] filters, final String outcome)
-            throws JsonProcessingException {
-        ObjectMapper objectMapper = jackson2Helper.buildObjectMapper(filters);
-        String json = objectMapper.writeValueAsString(testObj);
-
-        System.out.print("Filter: ");
-        for (int i = 0; i < filters.length; i++) {
-            System.out.print(filters[i] + ",");
-        }
-        System.out.println();
-
-        System.out.println("Result: " + json);
-
-        Assert.assertEquals(outcome, json);
-    }
-
-    private void assertAntFilter(final String[] filters, final String outcome) throws JsonProcessingException {
-        assertAntFilter(User.buildMySelf(), filters, outcome);
+    @Test
+    public void canFilterOutAKey() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"**", "!manager"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_canFilterOutAKey.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testExclusion() throws JsonProcessingException {
-        String[] filters = new String[] { "**", "!manager" };
-        assertAntFilter(filters,
-                "{\"address\":{\"streetName\":\"At my place\",\"streetNumber\":\"1\"},\"email\":\"somewhere@no.where\",\"firstName\":\"Martin\",\"lastName\":\"Frey\",\"reports\":[{\"address\":null,\"email\":\"report0@no.where\",\"firstName\":\"First 0\",\"lastName\":\"Doe 0\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report1@no.where\",\"firstName\":\"First 1\",\"lastName\":\"Doe 1\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report2@no.where\",\"firstName\":\"First 2\",\"lastName\":\"Doe 2\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report3@no.where\",\"firstName\":\"First 3\",\"lastName\":\"Doe 3\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report4@no.where\",\"firstName\":\"First 4\",\"lastName\":\"Doe 4\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report5@no.where\",\"firstName\":\"First 5\",\"lastName\":\"Doe 5\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report6@no.where\",\"firstName\":\"First 6\",\"lastName\":\"Doe 6\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report7@no.where\",\"firstName\":\"First 7\",\"lastName\":\"Doe 7\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report8@no.where\",\"firstName\":\"First 8\",\"lastName\":\"Doe 8\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report9@no.where\",\"firstName\":\"First 9\",\"lastName\":\"Doe 9\",\"manager\":null,\"reports\":null}]}");
+    public void canFilterOutAKeyWithOldPattern() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"**", "-manager"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_canFilterOutAKey.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testOldExclusionPattern() throws JsonProcessingException {
-        String[] filters = new String[] { "**", "-manager" };
-        assertAntFilter(filters,
-                "{\"address\":{\"streetName\":\"At my place\",\"streetNumber\":\"1\"},\"email\":\"somewhere@no.where\",\"firstName\":\"Martin\",\"lastName\":\"Frey\",\"reports\":[{\"address\":null,\"email\":\"report0@no.where\",\"firstName\":\"First 0\",\"lastName\":\"Doe 0\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report1@no.where\",\"firstName\":\"First 1\",\"lastName\":\"Doe 1\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report2@no.where\",\"firstName\":\"First 2\",\"lastName\":\"Doe 2\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report3@no.where\",\"firstName\":\"First 3\",\"lastName\":\"Doe 3\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report4@no.where\",\"firstName\":\"First 4\",\"lastName\":\"Doe 4\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report5@no.where\",\"firstName\":\"First 5\",\"lastName\":\"Doe 5\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report6@no.where\",\"firstName\":\"First 6\",\"lastName\":\"Doe 6\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report7@no.where\",\"firstName\":\"First 7\",\"lastName\":\"Doe 7\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report8@no.where\",\"firstName\":\"First 8\",\"lastName\":\"Doe 8\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report9@no.where\",\"firstName\":\"First 9\",\"lastName\":\"Doe 9\",\"manager\":null,\"reports\":null}]}");
+    public void canExcludeTwoKeys() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"**", "!manager", "!**.streetNumber"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_canExcludeTwoKeys.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testExclusion2() throws JsonProcessingException {
-        String[] filters = new String[] { "**", "!manager", "!**.streetNumber" };
-        assertAntFilter(filters,
-                "{\"address\":{\"streetName\":\"At my place\"},\"email\":\"somewhere@no.where\",\"firstName\":\"Martin\",\"lastName\":\"Frey\",\"reports\":[{\"address\":null,\"email\":\"report0@no.where\",\"firstName\":\"First 0\",\"lastName\":\"Doe 0\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report1@no.where\",\"firstName\":\"First 1\",\"lastName\":\"Doe 1\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report2@no.where\",\"firstName\":\"First 2\",\"lastName\":\"Doe 2\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report3@no.where\",\"firstName\":\"First 3\",\"lastName\":\"Doe 3\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report4@no.where\",\"firstName\":\"First 4\",\"lastName\":\"Doe 4\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report5@no.where\",\"firstName\":\"First 5\",\"lastName\":\"Doe 5\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report6@no.where\",\"firstName\":\"First 6\",\"lastName\":\"Doe 6\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report7@no.where\",\"firstName\":\"First 7\",\"lastName\":\"Doe 7\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report8@no.where\",\"firstName\":\"First 8\",\"lastName\":\"Doe 8\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report9@no.where\",\"firstName\":\"First 9\",\"lastName\":\"Doe 9\",\"manager\":null,\"reports\":null}]}");
+    public void canExtractAKey() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"firstName"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_canExtractAKey.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testFirstName() throws JsonProcessingException {
-        String[] filters = new String[] { "firstName" };
-        assertAntFilter(filters, "{\"firstName\":\"Martin\"}");
+    public void noFilterReturnAllObject() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"**"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_noFilterReturnAllObject.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testFull() throws JsonProcessingException {
-        String[] filters = new String[] { "**" };
-        assertAntFilter(filters,
-                "{\"address\":{\"streetName\":\"At my place\",\"streetNumber\":\"1\"},\"email\":\"somewhere@no.where\",\"firstName\":\"Martin\",\"lastName\":\"Frey\",\"manager\":{\"address\":null,\"email\":\"john.doe@no.where\",\"firstName\":\"John\",\"lastName\":\"Doe\",\"manager\":null,\"reports\":null},\"reports\":[{\"address\":null,\"email\":\"report0@no.where\",\"firstName\":\"First 0\",\"lastName\":\"Doe 0\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report1@no.where\",\"firstName\":\"First 1\",\"lastName\":\"Doe 1\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report2@no.where\",\"firstName\":\"First 2\",\"lastName\":\"Doe 2\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report3@no.where\",\"firstName\":\"First 3\",\"lastName\":\"Doe 3\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report4@no.where\",\"firstName\":\"First 4\",\"lastName\":\"Doe 4\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report5@no.where\",\"firstName\":\"First 5\",\"lastName\":\"Doe 5\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report6@no.where\",\"firstName\":\"First 6\",\"lastName\":\"Doe 6\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report7@no.where\",\"firstName\":\"First 7\",\"lastName\":\"Doe 7\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report8@no.where\",\"firstName\":\"First 8\",\"lastName\":\"Doe 8\",\"manager\":null,\"reports\":null},{\"address\":null,\"email\":\"report9@no.where\",\"firstName\":\"First 9\",\"lastName\":\"Doe 9\",\"manager\":null,\"reports\":null}]}");
+    public void canIncludeOnlySomePath() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"*", "address.*", "manager.firstName"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_canIncludeOnlySomePath.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testInclusion() throws JsonProcessingException {
-        String[] filters = new String[] { "*", "address.*", "manager.firstName" };
-        assertAntFilter(filters,
-                "{\"address\":{\"streetName\":\"At my place\",\"streetNumber\":\"1\"},\"email\":\"somewhere@no.where\",\"firstName\":\"Martin\",\"lastName\":\"Frey\",\"manager\":{\"firstName\":\"John\"},\"reports\":[{},{},{},{},{},{},{},{},{},{}]}");
+    public void canExtractManagerName() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"manager", "manager.firstName", "manager.lastName"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_canExtractManagerName.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testManagerNames() throws JsonProcessingException {
-        String[] filters = new String[] { "manager", "manager.firstName", "manager.lastName" };
-        assertAntFilter(filters, "{\"manager\":{\"firstName\":\"John\",\"lastName\":\"Doe\"}}");
+    public void testRecursive1Levels() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"**", "!manager"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_testRecursive1Levels.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildRecursive());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testRecursive1Levels() throws JsonProcessingException {
-        String[] filters = new String[] { "**", "!manager" };
-        assertAntFilter(User.buildRecursive(), filters,
-                "{\"address\":{\"streetName\":\"At my place\",\"streetNumber\":\"1\"},\"email\":\"somewhere@no.where\",\"firstName\":\"Martin\",\"lastName\":\"Frey\",\"reports\":null}");
+    public void extractOnlyReportFirstName() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"reports", "reports.firstName"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_extractOnlyReportFirstName.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
     @Test
-    public void testReports() throws JsonProcessingException {
-        String[] filters = new String[] { "reports", "reports.firstName" };
-        assertAntFilter(User.buildMySelf(), filters,
-                "{\"reports\":[{\"firstName\":\"First 0\"},{\"firstName\":\"First 1\"},{\"firstName\":\"First 2\"},{\"firstName\":\"First 3\"},{\"firstName\":\"First 4\"},{\"firstName\":\"First 5\"},{\"firstName\":\"First 6\"},{\"firstName\":\"First 7\"},{\"firstName\":\"First 8\"},{\"firstName\":\"First 9\"}]}");
+    public void extractOnlyReportFirstNameAlternativeFilter() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"reports.firstName"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_extractOnlyReportFirstName.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
+
     @Test
-    public void testReports2() throws JsonProcessingException {
-        String[] filters = new String[]{"reports.firstName"};
-        assertAntFilter(User.buildMySelf(), filters,
-                "{\"reports\":[{\"firstName\":\"First 0\"},{\"firstName\":\"First 1\"},{\"firstName\":\"First 2\"},{\"firstName\":\"First 3\"},{\"firstName\":\"First 4\"},{\"firstName\":\"First 5\"},{\"firstName\":\"First 6\"},{\"firstName\":\"First 7\"},{\"firstName\":\"First 8\"},{\"firstName\":\"First 9\"}]}");
-    }
-    @Test
-    public void testAllFirstLevelAndReportFirstName() throws JsonProcessingException {
-        String[] filters = new String[]{"*.firstName"};
-        assertAntFilter(User.buildMySelf(), filters,
-                "{\"address\":{},\"email\":\"somewhere@no.where\",\"firstName\":\"Martin\",\"lastName\":\"Frey\",\"manager\":{\"firstName\":\"John\"},\"reports\":[{\"firstName\":\"First 0\"},{\"firstName\":\"First 1\"},{\"firstName\":\"First 2\"},{\"firstName\":\"First 3\"},{\"firstName\":\"First 4\"},{\"firstName\":\"First 5\"},{\"firstName\":\"First 6\"},{\"firstName\":\"First 7\"},{\"firstName\":\"First 8\"},{\"firstName\":\"First 9\"}]}");
+    public void extractAllFirstLevelAndAPropertyFromEachSubtree() throws JsonProcessingException, IOException {
+        final String[] filters = new String[]{"*.firstName"};
+        final InputStream in = this.getClass().getResourceAsStream("AntPathFilterTest_extractAllFirstLevelAndAPropertyFromEachSubtree.json");
+        final JsonNode expected = defaultJackson.readTree(in);
+        final ObjectMapper filteringMapper = jackson2Helper.buildObjectMapper(filters);
+        final String gotString = filteringMapper.writeValueAsString(User.buildMySelf());
+        final JsonNode got = defaultJackson.readTree(gotString);
+        Assert.assertEquals(expected, got);
     }
 
 }

--- a/src/test/java/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest.java
+++ b/src/test/java/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest.java
@@ -91,5 +91,17 @@ public class AntPathFilterTest {
         assertAntFilter(User.buildMySelf(), filters,
                 "{\"reports\":[{\"firstName\":\"First 0\"},{\"firstName\":\"First 1\"},{\"firstName\":\"First 2\"},{\"firstName\":\"First 3\"},{\"firstName\":\"First 4\"},{\"firstName\":\"First 5\"},{\"firstName\":\"First 6\"},{\"firstName\":\"First 7\"},{\"firstName\":\"First 8\"},{\"firstName\":\"First 9\"}]}");
     }
+    @Test
+    public void testReports2() throws JsonProcessingException {
+        String[] filters = new String[]{"reports.firstName"};
+        assertAntFilter(User.buildMySelf(), filters,
+                "{\"reports\":[{\"firstName\":\"First 0\"},{\"firstName\":\"First 1\"},{\"firstName\":\"First 2\"},{\"firstName\":\"First 3\"},{\"firstName\":\"First 4\"},{\"firstName\":\"First 5\"},{\"firstName\":\"First 6\"},{\"firstName\":\"First 7\"},{\"firstName\":\"First 8\"},{\"firstName\":\"First 9\"}]}");
+    }
+    @Test
+    public void testAllFirstLevelAndReportFirstName() throws JsonProcessingException {
+        String[] filters = new String[]{"*.firstName"};
+        assertAntFilter(User.buildMySelf(), filters,
+                "{\"address\":{},\"email\":\"somewhere@no.where\",\"firstName\":\"Martin\",\"lastName\":\"Frey\",\"manager\":{\"firstName\":\"John\"},\"reports\":[{\"firstName\":\"First 0\"},{\"firstName\":\"First 1\"},{\"firstName\":\"First 2\"},{\"firstName\":\"First 3\"},{\"firstName\":\"First 4\"},{\"firstName\":\"First 5\"},{\"firstName\":\"First 6\"},{\"firstName\":\"First 7\"},{\"firstName\":\"First 8\"},{\"firstName\":\"First 9\"}]}");
+    }
 
 }

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canExcludeTwoKeys.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canExcludeTwoKeys.json
@@ -1,0 +1,79 @@
+{
+    "address": {
+        "streetName": "At my place"
+    },
+    "email": "somewhere@no.where",
+    "firstName": "Martin",
+    "lastName": "Frey",
+    "reports": [{
+            "address": null,
+            "email": "report0@no.where",
+            "firstName": "First 0",
+            "lastName": "Doe 0",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report1@no.where",
+            "firstName": "First 1",
+            "lastName": "Doe 1",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report2@no.where",
+            "firstName": "First 2",
+            "lastName": "Doe 2",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report3@no.where",
+            "firstName": "First 3",
+            "lastName": "Doe 3",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report4@no.where",
+            "firstName": "First 4",
+            "lastName": "Doe 4",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report5@no.where",
+            "firstName": "First 5",
+            "lastName": "Doe 5",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report6@no.where",
+            "firstName": "First 6",
+            "lastName": "Doe 6",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report7@no.where",
+            "firstName": "First 7",
+            "lastName": "Doe 7",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report8@no.where",
+            "firstName": "First 8",
+            "lastName": "Doe 8",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report9@no.where",
+            "firstName": "First 9",
+            "lastName": "Doe 9",
+            "manager": null,
+            "reports": null
+        }]
+}

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canExtractAKey.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canExtractAKey.json
@@ -1,0 +1,3 @@
+{
+    "firstName": "Martin"
+}

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canExtractManagerName.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canExtractManagerName.json
@@ -1,0 +1,6 @@
+{
+    "manager": {
+        "firstName": "John",
+        "lastName": "Doe"
+    }
+}

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canFilterOutAKey.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canFilterOutAKey.json
@@ -1,0 +1,80 @@
+{
+    "address": {
+        "streetName": "At my place",
+        "streetNumber": "1"
+    },
+    "email": "somewhere@no.where",
+    "firstName": "Martin",
+    "lastName": "Frey",
+    "reports": [{
+            "address": null,
+            "email": "report0@no.where",
+            "firstName": "First 0",
+            "lastName": "Doe 0",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report1@no.where",
+            "firstName": "First 1",
+            "lastName": "Doe 1",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report2@no.where",
+            "firstName": "First 2",
+            "lastName": "Doe 2",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report3@no.where",
+            "firstName": "First 3",
+            "lastName": "Doe 3",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report4@no.where",
+            "firstName": "First 4",
+            "lastName": "Doe 4",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report5@no.where",
+            "firstName": "First 5",
+            "lastName": "Doe 5",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report6@no.where",
+            "firstName": "First 6",
+            "lastName": "Doe 6",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report7@no.where",
+            "firstName": "First 7",
+            "lastName": "Doe 7",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report8@no.where",
+            "firstName": "First 8",
+            "lastName": "Doe 8",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report9@no.where",
+            "firstName": "First 9",
+            "lastName": "Doe 9",
+            "manager": null,
+            "reports": null
+        }]
+}

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canIncludeOnlySomePath.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_canIncludeOnlySomePath.json
@@ -1,0 +1,13 @@
+{
+    "address": {
+        "streetName": "At my place",
+        "streetNumber": "1"
+    },
+    "email": "somewhere@no.where",
+    "firstName": "Martin",
+    "lastName": "Frey",
+    "manager": {
+        "firstName": "John"
+    },
+    "reports": [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}]
+}

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_extractAllFirstLevelAndAPropertyFromEachSubtree.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_extractAllFirstLevelAndAPropertyFromEachSubtree.json
@@ -1,0 +1,30 @@
+{
+    "address": {},
+    "email": "somewhere@no.where",
+    "firstName": "Martin",
+    "lastName": "Frey",
+    "manager": {
+        "firstName": "John"
+    },
+    "reports": [{
+            "firstName": "First 0"
+        }, {
+            "firstName": "First 1"
+        }, {
+            "firstName": "First 2"
+        }, {
+            "firstName": "First 3"
+        }, {
+            "firstName": "First 4"
+        }, {
+            "firstName": "First 5"
+        }, {
+            "firstName": "First 6"
+        }, {
+            "firstName": "First 7"
+        }, {
+            "firstName": "First 8"
+        }, {
+            "firstName": "First 9"
+        }]
+}

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_extractOnlyReportFirstName.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_extractOnlyReportFirstName.json
@@ -1,0 +1,23 @@
+{
+    "reports": [{
+            "firstName": "First 0"
+        }, {
+            "firstName": "First 1"
+        }, {
+            "firstName": "First 2"
+        }, {
+            "firstName": "First 3"
+        }, {
+            "firstName": "First 4"
+        }, {
+            "firstName": "First 5"
+        }, {
+            "firstName": "First 6"
+        }, {
+            "firstName": "First 7"
+        }, {
+            "firstName": "First 8"
+        }, {
+            "firstName": "First 9"
+        }]
+}

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_noFilterReturnAllObject.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_noFilterReturnAllObject.json
@@ -1,0 +1,88 @@
+{
+    "address": {
+        "streetName": "At my place",
+        "streetNumber": "1"
+    },
+    "email": "somewhere@no.where",
+    "firstName": "Martin",
+    "lastName": "Frey",
+    "manager": {
+        "address": null,
+        "email": "john.doe@no.where",
+        "firstName": "John",
+        "lastName": "Doe",
+        "manager": null,
+        "reports": null
+    },
+    "reports": [{
+            "address": null,
+            "email": "report0@no.where",
+            "firstName": "First 0",
+            "lastName": "Doe 0",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report1@no.where",
+            "firstName": "First 1",
+            "lastName": "Doe 1",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report2@no.where",
+            "firstName": "First 2",
+            "lastName": "Doe 2",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report3@no.where",
+            "firstName": "First 3",
+            "lastName": "Doe 3",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report4@no.where",
+            "firstName": "First 4",
+            "lastName": "Doe 4",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report5@no.where",
+            "firstName": "First 5",
+            "lastName": "Doe 5",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report6@no.where",
+            "firstName": "First 6",
+            "lastName": "Doe 6",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report7@no.where",
+            "firstName": "First 7",
+            "lastName": "Doe 7",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report8@no.where",
+            "firstName": "First 8",
+            "lastName": "Doe 8",
+            "manager": null,
+            "reports": null
+        }, {
+            "address": null,
+            "email": "report9@no.where",
+            "firstName": "First 9",
+            "lastName": "Doe 9",
+            "manager": null,
+            "reports": null
+        }]
+}

--- a/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_testRecursive1Levels.json
+++ b/src/test/resources/ch/mfrey/jackson/antpathfilter/test/AntPathFilterTest_testRecursive1Levels.json
@@ -1,0 +1,10 @@
+{
+    "address": {
+        "streetName": "At my place",
+        "streetNumber": "1"
+    },
+    "email": "somewhere@no.where",
+    "firstName": "Martin",
+    "lastName": "Frey",
+    "reports": null
+}


### PR DESCRIPTION
I've added a "permessive" match strategy with this you can:

- preserve the object structure when the filter _a.b_ is specified (instead of specify filter for _a_ and _a.b_)
- can extract from different children type a property with same name eg: _*.id_ from: 
``` JSON
{
   "something": {
        "id": 1,
        "useless": "useless",
        "...." : "...."
    },
    "something-else": {
        "id": 1234,
        "other-value" : "other value",
        "...." : "...."
    }
}
```
lead to:
``` JSON
{
   "something": {
        "id": 1
    },
    "something-else": {
        "id": 1234
    }
}
```